### PR TITLE
Add sidebar_action key

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -35,6 +35,11 @@
   "web_accessible_resources": [
     "sidebar.html"
   ],
+  "sidebar_action": {
+    "default_icon": "img/icon.png",
+    "default_title" : "Sidebar",
+    "default_panel": "sidebar.html"
+  },
   "options_ui": {
     "page": "./options.html",
     "open_in_tab": true


### PR DESCRIPTION
This fixes the sidebar on Firefox 70.0.1 by specifying the sidebar_action in the manifest.