### PR TITLE
Add suport for css modules in storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,21 @@
+const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
+module.exports = {
+  module: {
+    rules: [
+      {
+        test:  /\.css$/,
+        loaders: [
+          require.resolve('style-loader'),
+          {
+            loader: require.resolve('css-loader'),
+            options: {
+              importLoaders: 1,
+              modules: true,
+              getLocalIdent: getCSSModuleLocalIdent,
+            },
+          }
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
Currently the react modules loaded via storybook don't link properly to corresponding css modules. This aims to fix that