### PR TITLE
add working content_scripts hot_reload

### DIFF
--- a/src/lib/js/hot-reload.js
+++ b/src/lib/js/hot-reload.js
@@ -1,0 +1,36 @@
+const filesInDirectory = dir => new Promise (resolve =>
+    dir.createReader ().readEntries (entries =>
+        Promise.all (entries.filter (e => e.name[0] !== '.').map (e =>
+            e.isDirectory
+                ? filesInDirectory (e)
+                : new Promise (resolve => e.file (resolve))
+        ))
+        .then (files => [].concat (...files))
+        .then (resolve)
+    )
+)
+
+const timestampForFilesInDirectory = dir =>
+        filesInDirectory (dir).then (files =>
+            files.map (f => f.name + f.lastModifiedDate).join ())
+
+const watchChanges = (dir, lastTimestamp) => {
+    timestampForFilesInDirectory (dir).then (timestamp => {
+        if (!lastTimestamp || (lastTimestamp === timestamp)) {
+            setTimeout (() => watchChanges (dir, timestamp), 1000) // retry after 1s
+        } else {
+            chrome.runtime.reload ()
+        }
+    })
+}
+
+chrome.management.getSelf (self => {
+    if (self.installType === 'development') {
+        chrome.runtime.getPackageDirectoryEntry (dir => watchChanges (dir))
+        chrome.tabs.query ({ active: true, lastFocusedWindow: true }, tabs => { // NB: see https://github.com/xpl/crx-hotreload/issues/5
+            if (tabs[0]) {
+                chrome.tabs.reload (tabs[0].id)
+            }
+        })
+    }
+})

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,6 +16,7 @@
   ],
   "background": {
     "scripts": [
+      "lib/js/hot-reload.js",
       "lib/js/browser-polyfill.js",
       "background.js"
     ]


### PR DESCRIPTION
closes https://github.com/kryptokinght/react-extension-boilerplate/issues/25

At this time, theres no hot-reload functionality, but [**this repo**](https://github.com/xpl/crx-hotreload) solves this problem! 

# How to test
1. Clone the branch
2. run `npm run start:chrome`
3. Show console - it says "content scripts loaded"
4. Change the `src/content_scripts/index.js` file content 
5. The chrome tab should auto-refresh and the console should update the text :)